### PR TITLE
Change TestAdapter to send messages to the current process' inbox

### DIFF
--- a/lib/mouth/adapters/test_adapter.ex
+++ b/lib/mouth/adapters/test_adapter.ex
@@ -14,12 +14,12 @@ defmodule Mouth.TestAdapter do
   end
 
   def deliver(message, _) do
-    IO.puts(message.body)
+    send(self(), {:sms, message})
     {:ok, [status: "Accepted", id: "test", datetime: to_string(DateTime.utc_now())]}
   end
 
   def status(_, config) do
-    IO.puts(inspect(config))
+    send(self(), {:config, config})
     {:ok, [status: "Accepted", id: "test", datetime: to_string(DateTime.utc_now())]}
   end
 

--- a/test/mouth/adapters/test_adapter_test.exs
+++ b/test/mouth/adapters/test_adapter_test.exs
@@ -2,8 +2,6 @@ defmodule Mouth.TestAdapterTest do
   use ExUnit.Case
   alias Mouth.Message
 
-  import ExUnit.CaptureIO
-
   @default_attrs [to: "+380501234567", body: "test"]
 
   defmodule TestSender do
@@ -24,10 +22,10 @@ defmodule Mouth.TestAdapterTest do
 
   test "TestSender.deliver/1 works as expected" do
     msg = Message.new_message(@default_attrs)
+    {:ok, _} = TestSender.deliver(msg)
 
-    assert capture_io(fn ->
-             TestSender.deliver(msg)
-           end) == "test\n"
+    assert_receive {:sms, message}
+    assert message.body == "test"
   end
 
   test "TestSender.deliver/1 raises when data is invalid" do
@@ -57,8 +55,7 @@ defmodule Mouth.TestAdapterTest do
       System.delete_env("GATEWAY_URL")
     end)
 
-    assert capture_io(fn ->
-             TestSender.status(msg)
-           end) == "%{adapter: Mouth.TestAdapter, gateway_url: \"systemurl.com:4000\"}\n"
+    {:ok, _} = TestSender.status(msg)
+    assert_receive {:config, %{adapter: Mouth.TestAdapter, gateway_url: "systemurl.com:4000"}}
   end
 end


### PR DESCRIPTION
This allows the use `assert_receive` over `ExUnit.CaptureIO.capture_io/1` in tests, and prevents message bodies from being leaked into the standard output on downstream applications.